### PR TITLE
ci: isolate release candidate concurrency

### DIFF
--- a/.github/workflows/exact-package-candidate.yml
+++ b/.github/workflows/exact-package-candidate.yml
@@ -22,7 +22,9 @@ on:
           - dry-run
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # A nightly or manually dispatched matrix must never cancel the push run that
+  # authorizes a release for the same main commit.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/scripts/__tests__/ci-fixtures.test.mjs
+++ b/scripts/__tests__/ci-fixtures.test.mjs
@@ -66,6 +66,18 @@ test('root-level Apple workflows run CocoaPods from the bare example', () => {
   }
 });
 
+test('release-authorizing package candidates do not share concurrency with validation runs', () => {
+  const workflow = readFileSync(
+    resolve(repository, '.github/workflows/exact-package-candidate.yml'),
+    'utf8'
+  );
+
+  assert.match(
+    workflow,
+    /group: \$\{\{ github\.workflow \}\}-\$\{\{ github\.event_name \}\}-\$\{\{ github\.ref \}\}/
+  );
+});
+
 test('Apple contract jobs prepare the Detox framework cache explicitly', () => {
   const workflow = readFileSync(
     resolve(repository, '.github/workflows/exact-package-candidate.yml'),


### PR DESCRIPTION
## Summary

- isolate exact-package candidate concurrency by event type
- prevent nightly/manual runs from cancelling the push candidate that authorizes a release
- add a release-policy regression test

## Validation

- `yarn test:release`
- `yarn lint`

Closes the workflow race discovered while implementing #44.