### PR TITLE
ci: isolate release and device-contract sessions

### DIFF
--- a/.changeset/reliable-device-contract-gates.md
+++ b/.changeset/reliable-device-contract-gates.md
@@ -1,0 +1,5 @@
+---
+'react-native-reorderable': patch
+---
+
+Isolate release device-contract sessions and evidence so mixed pointer-driver validation cannot reuse stale Detox clients or results.

--- a/.changeset/stable-v1-release.md
+++ b/.changeset/stable-v1-release.md
@@ -3,3 +3,7 @@
 ---
 
 Publish the stable v1 portable reorder and drag-and-drop contract.
+
+The v1 support boundary is React Native 0.82–0.86 on the New Architecture and Hermes, React 19.1–19.x, Reanimated 4.3–4.6, Gesture Handler 3.x, Worklets 0.8–0.12, iOS 15.1+, and Android API 24+. The exact release candidate is validated in clean bare consumers at the minimum profile (React Native 0.82.1, React 19.1.1, Reanimated 4.3.0, Gesture Handler 3.0.0, and Worklets 0.8.1), the maximum profile (React Native 0.86.2, React 19.2.3, Reanimated 4.5.3, Gesture Handler 3.2.1, and Worklets 0.11.4), and an Expo SDK 57.0.14 development build at the maximum profile.
+
+The portable contract guarantees application-owned data and selection, identity-based committed reorder and drag-and-drop outcomes, atomic canonical multi-selection, semantic destination acceptance, cancellation, accessible reorder and drop actions, and list auto-scroll across the native and fallback engines. Native SwiftUI reorder is capability-dependent on iOS 27+; supported older iOS versions and Android use the fallback engine. Engine presentation may differ while application-observable semantics remain portable.

--- a/.detoxrc.cjs
+++ b/.detoxrc.cjs
@@ -5,7 +5,7 @@ module.exports = {
     // Android 16 may resolve localhost to IPv6 while adb reverse exposes the
     // host listener over IPv4. Keep Detox's managed server and tunnel on the
     // same explicit loopback address.
-    server: 'ws://127.0.0.1:8099',
+    server: process.env.ISSUE39_DETOX_SERVER_URL ?? 'ws://127.0.0.1:8099',
     autoStart: true,
   },
   testRunner: {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - checks_requested
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: docs-${{ github.ref }}
+  group: docs-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/scripts/__tests__/ci-fixtures.test.mjs
+++ b/scripts/__tests__/ci-fixtures.test.mjs
@@ -66,16 +66,20 @@ test('root-level Apple workflows run CocoaPods from the bare example', () => {
   }
 });
 
-test('release-authorizing package candidates do not share concurrency with validation runs', () => {
-  const workflow = readFileSync(
-    resolve(repository, '.github/workflows/exact-package-candidate.yml'),
-    'utf8'
-  );
+test('release-authorizing push gates do not share concurrency with other events', () => {
+  for (const workflowPath of [
+    '.github/workflows/ci.yml',
+    '.github/workflows/docs.yml',
+    '.github/workflows/exact-package-candidate.yml',
+  ]) {
+    const workflow = readFileSync(resolve(repository, workflowPath), 'utf8');
 
-  assert.match(
-    workflow,
-    /group: \$\{\{ github\.workflow \}\}-\$\{\{ github\.event_name \}\}-\$\{\{ github\.ref \}\}/
-  );
+    assert.match(
+      workflow,
+      /group: .*\$\{\{ github\.event_name \}\}.*\$\{\{ github\.ref \}\}/,
+      workflowPath
+    );
+  }
 });
 
 test('Apple contract jobs prepare the Detox framework cache explicitly', () => {

--- a/scripts/prepare-agent-device-ios-runner.mjs
+++ b/scripts/prepare-agent-device-ios-runner.mjs
@@ -46,16 +46,16 @@ const sessionName = 'issue39-ios-runner-preflight';
 const stateRoot = resolve(
   'artifacts/issue-39/agent-device',
   configuration,
+  ...(process.env.ISSUE39_MATRIX_ATTEMPT == null
+    ? []
+    : ['attempts', process.env.ISSUE39_MATRIX_ATTEMPT]),
   'replay-daemon-state'
 );
 const environment = {
   ...process.env,
   AGENT_DEVICE_STATE_DIR: stateRoot,
 };
-const deepLinkConfirmationMarker = resolve(
-  stateRoot,
-  'deep-link-confirmed'
-);
+const deepLinkConfirmationMarker = resolve(stateRoot, 'deep-link-confirmed');
 const runAgentDevice = (...args) =>
   run(agentDevice, args, { env: environment });
 const runSessionCommand = (...args) =>
@@ -70,9 +70,7 @@ const runSessionCommand = (...args) =>
   );
 const requireSuccess = (result, description) => {
   if (result.status !== 0)
-    throw new Error(
-      `${description} exited ${result.status ?? result.signal}`
-    );
+    throw new Error(`${description} exited ${result.status ?? result.signal}`);
 };
 const defaultEnvironment = { ...process.env };
 delete defaultEnvironment.AGENT_DEVICE_STATE_DIR;

--- a/scripts/run-agent-device-pointer.mjs
+++ b/scripts/run-agent-device-pointer.mjs
@@ -114,6 +114,9 @@ await mkdir(recordingDirectory, { recursive: true });
 const replayStateRoot = resolve(
   'artifacts/issue-39/agent-device',
   configuration,
+  ...(process.env.ISSUE39_MATRIX_ATTEMPT == null
+    ? []
+    : ['attempts', process.env.ISSUE39_MATRIX_ATTEMPT]),
   'replay-daemon-state'
 );
 await mkdir(replayStateRoot, { recursive: true });

--- a/scripts/run-device-contract-isolated.mjs
+++ b/scripts/run-device-contract-isolated.mjs
@@ -20,18 +20,6 @@ const pointerDrivers = JSON.parse(
 const applicable = scenarios.filter(({ platforms }) =>
   platforms.includes(platform)
 );
-const requiresAgentDevice = applicable.some(
-  ({ id }) =>
-    pointerDrivers.routes?.[configuration]?.[id] === 'agent-device'
-);
-if (platform === 'ios' && requiresAgentDevice) {
-  const preflight = spawnSync(
-    process.execPath,
-    ['scripts/prepare-agent-device-ios-runner.mjs', configuration],
-    { stdio: 'inherit', timeout: 600000 }
-  );
-  if (preflight.status !== 0) process.exit(75);
-}
 const artifactRoot = resolve(
   'artifacts/issue-39/detox',
   configuration,
@@ -56,6 +44,7 @@ const agentDeviceRoot = resolve(
 const replayStateRoot = resolve(
   'artifacts/issue-39/agent-device',
   configuration,
+  ...attemptSegments,
   'replay-daemon-state'
 );
 const stopReplayDaemon = () =>
@@ -77,11 +66,38 @@ const hasObservedScenarioOutcome = (outcomeFile, scenarioId) => {
 };
 const table = [];
 const outcomes = {};
+let agentDevicePrepared = false;
+const detoxPortBlockSize = 20;
+if (applicable.length > detoxPortBlockSize)
+  throw new Error(
+    `At most ${detoxPortBlockSize} isolated scenarios are supported`
+  );
+const detoxPortBase =
+  20000 + (Math.abs(process.pid) % 1000) * detoxPortBlockSize;
+const detoxServerUrlForCase = (scenarioIndex) =>
+  `ws://127.0.0.1:${detoxPortBase + scenarioIndex}`;
 
 mkdirSync(artifactRoot, { recursive: true });
 mkdirSync(caseOutcomeRoot, { recursive: true });
 
-for (const scenario of applicable) {
+for (const [scenarioIndex, scenario] of applicable.entries()) {
+  const driver = pointerDrivers.routes?.[configuration]?.[scenario.id];
+  if (driver === 'agent-device' && !agentDevicePrepared) {
+    if (platform === 'ios') {
+      const preflight = spawnSync(
+        process.execPath,
+        ['scripts/prepare-agent-device-ios-runner.mjs', configuration],
+        { stdio: 'inherit', timeout: 600000 }
+      );
+      if (preflight.status !== 0) process.exit(75);
+    }
+    agentDevicePrepared = true;
+  }
+  if (driver !== 'agent-device' && agentDevicePrepared) {
+    stopReplayDaemon();
+    agentDevicePrepared = false;
+  }
+
   if (platform === 'android') {
     spawnSync(
       'adb',
@@ -100,7 +116,6 @@ for (const scenario of applicable) {
 
   const outcomeFile = resolve(caseOutcomeRoot, `${scenario.id}.json`);
   const startedAt = Date.now();
-  const driver = pointerDrivers.routes?.[configuration]?.[scenario.id];
   const result =
     driver === 'agent-device'
       ? spawnSync(
@@ -145,6 +160,7 @@ for (const scenario of applicable) {
             env: {
               ...process.env,
               AGENT_DEVICE_STATE_DIR: replayStateRoot,
+              ISSUE39_DETOX_SERVER_URL: detoxServerUrlForCase(scenarioIndex),
               ISSUE39_FEEDBACK_DIR: resolve(feedbackRoot, scenario.id),
               ISSUE39_OUTCOME_FILE: outcomeFile,
             },
@@ -162,8 +178,13 @@ for (const scenario of applicable) {
   );
   const infrastructureFailure =
     !passed &&
-    (result.status == null || result.signal != null || !reachedContractAssertion);
-  if (driver === 'agent-device' && !passed) stopReplayDaemon();
+    (result.status == null ||
+      result.signal != null ||
+      !reachedContractAssertion);
+  if (driver === 'agent-device' && !passed) {
+    stopReplayDaemon();
+    agentDevicePrepared = false;
+  }
   table.push({
     id: scenario.id,
     durationMs: Date.now() - startedAt,
@@ -182,7 +203,7 @@ for (const scenario of applicable) {
   }
 }
 
-if (requiresAgentDevice) stopReplayDaemon();
+if (agentDevicePrepared) stopReplayDaemon();
 
 const tablePath = resolve(
   'artifacts/issue-39/device-tables',

--- a/scripts/run-device-contract-job.mjs
+++ b/scripts/run-device-contract-job.mjs
@@ -4,6 +4,7 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
+  rmSync,
   writeFileSync,
 } from 'node:fs';
 import { dirname, resolve } from 'node:path';
@@ -52,10 +53,62 @@ function publishSuccessfulAttempt(attempt) {
   );
 }
 
+function clearPublishedEvidence() {
+  for (const category of [
+    'agent-device',
+    'detox',
+    'feedback',
+    'outcomes-by-case',
+  ])
+    rmSync(resolve('artifacts/issue-39', category, configuration), {
+      force: true,
+      recursive: true,
+    });
+  for (const [category, suffix] of [
+    ['device-tables', '.json'],
+    ['device-tables', '-job.json'],
+    ['outcomes', '.json'],
+  ])
+    rmSync(
+      resolve('artifacts/issue-39', category, `${configuration}${suffix}`),
+      { force: true }
+    );
+}
+
+function clearAttemptEvidence(attempt) {
+  for (const category of [
+    'agent-device',
+    'detox',
+    'feedback',
+    'outcomes-by-case',
+  ])
+    rmSync(
+      resolve(
+        'artifacts/issue-39',
+        category,
+        configuration,
+        'attempts',
+        attempt
+      ),
+      { force: true, recursive: true }
+    );
+  for (const category of ['device-tables', 'outcomes'])
+    rmSync(
+      resolve(
+        'artifacts/issue-39',
+        category,
+        `${configuration}-${attempt}.json`
+      ),
+      { force: true }
+    );
+}
+
+clearPublishedEvidence();
 const attempts = [];
 let finalStatus = 1;
 for (let index = 1; index <= 2; index += 1) {
   const attempt = `attempt-${index}`;
+  clearAttemptEvidence(attempt);
   const startedAt = Date.now();
   const resetResult = configuration.startsWith('ios')
     ? spawnSync(

--- a/src/__tests__/issue39-device-contract.test.ts
+++ b/src/__tests__/issue39-device-contract.test.ts
@@ -808,7 +808,7 @@ console.log(JSON.stringify({
       "globalTeardown: 'detox/runners/jest/globalTeardown'"
     );
     expect(config).toContain("launchApp: 'auto'");
-    expect(config).toContain("server: 'ws://127.0.0.1:8099'");
+    expect(config).toContain("'ws://127.0.0.1:8099'");
     expect(config).toContain('autoStart: true');
     expect(config).toContain('-PdetoxBuild=true');
     expect(config).toContain(
@@ -886,6 +886,7 @@ console.log(JSON.stringify({
     );
     const jobRunner = read('scripts/run-device-contract-job.mjs');
     const iosReset = read('scripts/reset-device-contract-ios-simulator.mjs');
+    const detoxConfig = read('.detoxrc.cjs');
     const workflow = read('.github/workflows/exact-package-candidate.yml');
 
     expect(runner.indexOf('onActionStarted?.();')).toBeLessThan(
@@ -919,8 +920,17 @@ console.log(JSON.stringify({
     );
     expect(
       isolatedRunner.indexOf('prepare-agent-device-ios-runner')
-    ).toBeLessThan(
+    ).toBeGreaterThan(
       isolatedRunner.indexOf('for (const scenario of applicable)')
+    );
+    expect(isolatedRunner).toContain(
+      "if (driver !== 'agent-device' && agentDevicePrepared)"
+    );
+    expect(isolatedRunner).toMatch(
+      /ISSUE39_DETOX_SERVER_URL:\s*detoxServerUrlForCase\(/
+    );
+    expect(detoxConfig).toContain(
+      "process.env.ISSUE39_DETOX_SERVER_URL ?? 'ws://127.0.0.1:8099'"
     );
     expect(isolatedRunner).toContain('process.exit(75)');
     expect(isolatedRunner).toContain(
@@ -928,8 +938,9 @@ console.log(JSON.stringify({
     );
     expect(isolatedRunner).toMatch(/AGENT_DEVICE_STATE_DIR:\s*replayStateRoot/);
     expect(isolatedRunner).toContain(
-      'if (requiresAgentDevice) stopReplayDaemon()'
+      'if (agentDevicePrepared) stopReplayDaemon()'
     );
+    expect(isolatedRunner).toContain('...attemptSegments,');
     expect(isolatedRunner).not.toMatch(/retry|retries/i);
     expect(iosRunnerPreflight).toMatch(
       /runAgentDevice\(\s*'prepare',\s*'ios-runner'/
@@ -952,6 +963,8 @@ console.log(JSON.stringify({
     expect(iosRunnerPreflight).toContain('stopDefaultDaemon');
     expect(jobRunner).toContain('scripts/run-device-contract-isolated.mjs');
     expect(jobRunner).toContain('reset-device-contract-ios-simulator.mjs');
+    expect(jobRunner).toContain('clearPublishedEvidence()');
+    expect(jobRunner).toContain('clearAttemptEvidence(attempt)');
     expect(iosReset).toContain("['simctl', 'shutdown', target.udid]");
     expect(iosReset).toContain("['simctl', 'erase', target.udid]");
     expect(iosReset).not.toContain("['simctl', 'shutdown', 'all']");


### PR DESCRIPTION
## Summary

- isolate CI and documentation concurrency by event type so late PR jobs cannot cancel release-authorizing push gates
- give every isolated Detox scenario its own server port and stop the Agent Device daemon at pointer-driver boundaries
- scope device-runner state by matrix attempt and delete stale published/attempt evidence before validation
- add regression coverage and a Changeset for the release-gate reliability fix

## Root cause

The mixed iOS 26 matrix launched every isolated Detox process on port 8099. A still-running app client from the preceding case could connect to the next server before its intended test client, producing `Cannot forward the message to the Detox client`. Committed evidence could then make a failed run appear successful.

## Validation

- `yarn lint`
- `yarn typecheck`
- `yarn test:release` — 16/16
- `yarn test --runInBand` — 28 suites, 302 tests
- local exact `ios26.auto-fallback` replay — 13/13 scenarios, 0 Detox disconnects
- `git diff --check`

Follow-up to the gate race and intermittent device-contract failure found while implementing #44.