### PR TITLE
fix(ci): drain iOS runner before drag evidence

### DIFF
--- a/e2e/contracts/outcome-observation.cjs
+++ b/e2e/contracts/outcome-observation.cjs
@@ -55,7 +55,7 @@ function agentDeviceReplayScript({
     ...(recordingPath == null
       ? []
       : [`record start ${quote(recordingPath)} --scope device`]),
-    'wait 1000',
+    `wait ${timing.preGestureSettleMs}`,
     `screenshot ${quote(gestureMarkerPath)}`,
     `gesture drag ${quote(sourceSelector)} ${quote(destinationSelector)} ${timing.sourceHoldMs} ${timing.moveBudgetMs} ${timing.destinationHoldMs}`,
     ...expectedLabels.map((label) => `wait ${quote(label)} 15000`),

--- a/e2e/contracts/pointer-drivers.json
+++ b/e2e/contracts/pointer-drivers.json
@@ -101,6 +101,7 @@
       "free-form-reorder": {
         "driver": "agent-device",
         "semanticTargetLabel": "Card row 4",
+        "sourceSelector": { "testID": "fallback-wrapper-card-0" },
         "destinationSelector": {
           "relation": "namedTargetCenterAfterSourceLift",
           "label": "Card row 4"

--- a/e2e/contracts/pointer-timing.json
+++ b/e2e/contracts/pointer-timing.json
@@ -1,7 +1,8 @@
 {
   "sourceHoldMs": 650,
-  "agentDeviceSourceHoldMs": 1200,
+  "agentDeviceSourceHoldMs": 1000,
   "moveBudgetMs": 1200,
+  "agentDeviceMoveBudgetMs": 1000,
   "preGestureSettleMs": 6000,
   "settleMarginMs": 1650,
   "agentDeviceSettleMarginMs": 3500,

--- a/e2e/contracts/pointer-timing.json
+++ b/e2e/contracts/pointer-timing.json
@@ -1,8 +1,8 @@
 {
   "sourceHoldMs": 650,
-  "agentDeviceSourceHoldMs": 1000,
+  "agentDeviceSourceHoldMs": 1200,
   "moveBudgetMs": 1200,
-  "agentDeviceMoveBudgetMs": 1000,
+  "agentDeviceMoveBudgetMs": 800,
   "preGestureSettleMs": 6000,
   "settleMarginMs": 1650,
   "agentDeviceSettleMarginMs": 3500,

--- a/e2e/contracts/pointer-timing.json
+++ b/e2e/contracts/pointer-timing.json
@@ -1,6 +1,7 @@
 {
   "sourceHoldMs": 650,
   "moveBudgetMs": 1200,
+  "preGestureSettleMs": 6000,
   "settleMarginMs": 1650,
   "agentDeviceSettleMarginMs": 3500,
   "predecessorCenterSettleMarginMs": 5000,

--- a/e2e/contracts/pointer-timing.json
+++ b/e2e/contracts/pointer-timing.json
@@ -1,5 +1,6 @@
 {
   "sourceHoldMs": 650,
+  "agentDeviceSourceHoldMs": 1200,
   "moveBudgetMs": 1200,
   "preGestureSettleMs": 6000,
   "settleMarginMs": 1650,

--- a/scripts/__tests__/agent-device-replay.test.mjs
+++ b/scripts/__tests__/agent-device-replay.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const timing = JSON.parse(
+  readFileSync(
+    new URL('../../e2e/contracts/pointer-timing.json', import.meta.url),
+    'utf8'
+  )
+);
+const { agentDeviceReplayScript } = require(
+  fileURLToPath(
+    new URL('../../e2e/contracts/outcome-observation.cjs', import.meta.url)
+  )
+);
+
+test('the iOS runner drains before held-pointer timing begins', () => {
+  assert.ok(timing.preGestureSettleMs >= 5000);
+  const replay = agentDeviceReplayScript({
+    acceptDeepLinkPrompt: false,
+    baselinePath: '/tmp/baseline.png',
+    deepLink: 'reorderable://lab/free-form?engine=auto',
+    destinationSelector: 'id="card-card-3"',
+    expectedLabels: ['Callback count: 1'],
+    gestureMarkerPath: '/tmp/gesture-start.png',
+    initialLabels: ['Callback count: 0'],
+    platform: 'ios',
+    sourceSelector: 'id="card-card-0"',
+    terminalPath: '/tmp/terminal.png',
+    timing,
+  });
+
+  assert.match(
+    replay,
+    /wait 6000\nscreenshot "\/tmp\/gesture-start\.png"\ngesture drag/
+  );
+});

--- a/scripts/__tests__/agent-device-replay.test.mjs
+++ b/scripts/__tests__/agent-device-replay.test.mjs
@@ -19,6 +19,7 @@ const { agentDeviceReplayScript } = require(
 
 test('the iOS runner drains before held-pointer timing begins', () => {
   assert.ok(timing.preGestureSettleMs >= 5000);
+  assert.ok(timing.agentDeviceSourceHoldMs >= 1000);
   const replay = agentDeviceReplayScript({
     acceptDeepLinkPrompt: false,
     baselinePath: '/tmp/baseline.png',
@@ -30,11 +31,14 @@ test('the iOS runner drains before held-pointer timing begins', () => {
     platform: 'ios',
     sourceSelector: 'id="card-card-0"',
     terminalPath: '/tmp/terminal.png',
-    timing,
+    timing: {
+      ...timing,
+      sourceHoldMs: timing.agentDeviceSourceHoldMs,
+    },
   });
 
   assert.match(
     replay,
-    /wait 6000\nscreenshot "\/tmp\/gesture-start\.png"\ngesture drag/
+    /wait 6000\nscreenshot "\/tmp\/gesture-start\.png"\ngesture drag .* 1200 1200 8000/
   );
 });

--- a/scripts/__tests__/agent-device-replay.test.mjs
+++ b/scripts/__tests__/agent-device-replay.test.mjs
@@ -20,6 +20,12 @@ const { agentDeviceReplayScript } = require(
 test('the iOS runner drains before held-pointer timing begins', () => {
   assert.ok(timing.preGestureSettleMs >= 5000);
   assert.ok(timing.agentDeviceSourceHoldMs >= 1000);
+  assert.ok(
+    timing.agentDeviceSourceHoldMs +
+      timing.agentDeviceMoveBudgetMs +
+      timing.destinationHoldMs <=
+      10000
+  );
   const replay = agentDeviceReplayScript({
     acceptDeepLinkPrompt: false,
     baselinePath: '/tmp/baseline.png',
@@ -33,12 +39,13 @@ test('the iOS runner drains before held-pointer timing begins', () => {
     terminalPath: '/tmp/terminal.png',
     timing: {
       ...timing,
+      moveBudgetMs: timing.agentDeviceMoveBudgetMs,
       sourceHoldMs: timing.agentDeviceSourceHoldMs,
     },
   });
 
   assert.match(
     replay,
-    /wait 6000\nscreenshot "\/tmp\/gesture-start\.png"\ngesture drag .* 1200 1200 8000/
+    /wait 6000\nscreenshot "\/tmp\/gesture-start\.png"\ngesture drag .* 1000 1000 8000/
   );
 });

--- a/scripts/__tests__/agent-device-replay.test.mjs
+++ b/scripts/__tests__/agent-device-replay.test.mjs
@@ -52,7 +52,7 @@ test('the iOS runner drains before held-pointer timing begins', () => {
 
   assert.match(
     replay,
-    /wait 6000\nscreenshot "\/tmp\/gesture-start\.png"\ngesture drag .* 1000 1000 8000/
+    /wait 6000\nscreenshot "\/tmp\/gesture-start\.png"\ngesture drag .* 1200 800 8000/
   );
 });
 

--- a/scripts/__tests__/agent-device-replay.test.mjs
+++ b/scripts/__tests__/agent-device-replay.test.mjs
@@ -11,6 +11,12 @@ const timing = JSON.parse(
     'utf8'
   )
 );
+const drivers = JSON.parse(
+  readFileSync(
+    new URL('../../e2e/contracts/pointer-drivers.json', import.meta.url),
+    'utf8'
+  )
+);
 const { agentDeviceReplayScript } = require(
   fileURLToPath(
     new URL('../../e2e/contracts/outcome-observation.cjs', import.meta.url)
@@ -47,5 +53,13 @@ test('the iOS runner drains before held-pointer timing begins', () => {
   assert.match(
     replay,
     /wait 6000\nscreenshot "\/tmp\/gesture-start\.png"\ngesture drag .* 1000 1000 8000/
+  );
+});
+
+test('iOS 26 free-form activation targets the fallback gesture host', () => {
+  assert.equal(
+    drivers.overrides['ios26.auto-fallback']['free-form-reorder']
+      .sourceSelector.testID,
+    'fallback-wrapper-card-0'
   );
 });

--- a/scripts/run-agent-device-pointer.mjs
+++ b/scripts/run-agent-device-pointer.mjs
@@ -39,9 +39,13 @@ const feedbackSettleMarginMs =
   override.destinationSelector.relation === 'predecessorCenter'
     ? pointerTiming.predecessorCenterSettleMarginMs
     : pointerTiming.agentDeviceSettleMarginMs;
+const agentDeviceTiming = {
+  ...pointerTiming,
+  sourceHoldMs: pointerTiming.agentDeviceSourceHoldMs,
+};
 const feedbackFirstSampleMs =
-  pointerTiming.sourceHoldMs +
-  pointerTiming.moveBudgetMs +
+  agentDeviceTiming.sourceHoldMs +
+  agentDeviceTiming.moveBudgetMs +
   feedbackSettleMarginMs;
 
 let targetId;
@@ -277,7 +281,7 @@ try {
       recordingPath: platform === 'ios' ? undefined : recordingPath,
       sourceSelector,
       terminalPath: resolve(feedbackDirectory, 'terminal.png'),
-      timing: pointerTiming,
+      timing: agentDeviceTiming,
     })
   );
   const previousBaselineMtime = await stat(baselinePath)

--- a/scripts/run-agent-device-pointer.mjs
+++ b/scripts/run-agent-device-pointer.mjs
@@ -41,6 +41,7 @@ const feedbackSettleMarginMs =
     : pointerTiming.agentDeviceSettleMarginMs;
 const agentDeviceTiming = {
   ...pointerTiming,
+  moveBudgetMs: pointerTiming.agentDeviceMoveBudgetMs,
   sourceHoldMs: pointerTiming.agentDeviceSourceHoldMs,
 };
 const feedbackFirstSampleMs =

--- a/scripts/run-agent-device-pointer.mjs
+++ b/scripts/run-agent-device-pointer.mjs
@@ -237,7 +237,10 @@ try {
       scenario.selectors.find((selector) => selector.label === label)?.testID;
     return testId == null ? `label="${label}"` : `id="${testId}"`;
   };
-  const sourceSelector = selectorForLabel(scenario.action.sourceLabel);
+  const sourceSelector = selectorForLabel(
+    scenario.action.sourceLabel,
+    override.sourceSelector?.testID
+  );
   const destinationLabel =
     override.destinationSelector.relation === 'predecessorCenter'
       ? (override.destinationSelector.label ??

--- a/src/__tests__/issue39-device-contract.test.ts
+++ b/src/__tests__/issue39-device-contract.test.ts
@@ -311,7 +311,6 @@ describe('issue 39 portable device contract', () => {
         timing: {
           destinationHoldMs: number;
           moveBudgetMs: number;
-          preGestureSettleMs: number;
           sourceHoldMs: number;
         };
       }) => string;
@@ -375,7 +374,6 @@ describe('issue 39 portable device contract', () => {
         timing: {
           destinationHoldMs: 8000,
           moveBudgetMs: 1200,
-          preGestureSettleMs: 6000,
           sourceHoldMs: 650,
         },
       })
@@ -398,7 +396,6 @@ describe('issue 39 portable device contract', () => {
         timing: {
           destinationHoldMs: 8000,
           moveBudgetMs: 1200,
-          preGestureSettleMs: 6000,
           sourceHoldMs: 650,
         },
       })
@@ -419,7 +416,6 @@ describe('issue 39 portable device contract', () => {
       timing: {
         destinationHoldMs: 8000,
         moveBudgetMs: 1200,
-        preGestureSettleMs: 6000,
         sourceHoldMs: 650,
       },
     });
@@ -428,9 +424,6 @@ describe('issue 39 portable device contract', () => {
     );
     expect(iosReplay).not.toContain('record start');
     expect(iosReplay).not.toContain('record stop');
-    expect(iosReplay).toContain(
-      'wait 6000\nscreenshot "/tmp/gesture-start.png"\ngesture drag'
-    );
     expect(
       observation.agentDeviceReplayScript({
         acceptDeepLinkPrompt: false,
@@ -447,7 +440,6 @@ describe('issue 39 portable device contract', () => {
         timing: {
           destinationHoldMs: 8000,
           moveBudgetMs: 1200,
-          preGestureSettleMs: 6000,
           sourceHoldMs: 650,
         },
       })
@@ -724,7 +716,6 @@ console.log(JSON.stringify({
       agentDeviceSettleMarginMs: number;
       destinationHoldMs: number;
       moveBudgetMs: number;
-      preGestureSettleMs: number;
       predecessorCenterSettleMarginMs: number;
       sampleCount: number;
       sampleIntervalMs: number;
@@ -733,8 +724,6 @@ console.log(JSON.stringify({
     };
     const detoxRunner = read('e2e/contracts/portable-contract.e2e.cjs');
     const agentDeviceRunner = read('scripts/run-agent-device-pointer.mjs');
-
-    expect(timing.preGestureSettleMs).toBeGreaterThanOrEqual(5000);
 
     expect(
       pointerScenarios.every(

--- a/src/__tests__/issue39-device-contract.test.ts
+++ b/src/__tests__/issue39-device-contract.test.ts
@@ -311,6 +311,7 @@ describe('issue 39 portable device contract', () => {
         timing: {
           destinationHoldMs: number;
           moveBudgetMs: number;
+          preGestureSettleMs: number;
           sourceHoldMs: number;
         };
       }) => string;
@@ -374,6 +375,7 @@ describe('issue 39 portable device contract', () => {
         timing: {
           destinationHoldMs: 8000,
           moveBudgetMs: 1200,
+          preGestureSettleMs: 6000,
           sourceHoldMs: 650,
         },
       })
@@ -396,6 +398,7 @@ describe('issue 39 portable device contract', () => {
         timing: {
           destinationHoldMs: 8000,
           moveBudgetMs: 1200,
+          preGestureSettleMs: 6000,
           sourceHoldMs: 650,
         },
       })
@@ -416,6 +419,7 @@ describe('issue 39 portable device contract', () => {
       timing: {
         destinationHoldMs: 8000,
         moveBudgetMs: 1200,
+        preGestureSettleMs: 6000,
         sourceHoldMs: 650,
       },
     });
@@ -424,6 +428,9 @@ describe('issue 39 portable device contract', () => {
     );
     expect(iosReplay).not.toContain('record start');
     expect(iosReplay).not.toContain('record stop');
+    expect(iosReplay).toContain(
+      'wait 6000\nscreenshot "/tmp/gesture-start.png"\ngesture drag'
+    );
     expect(
       observation.agentDeviceReplayScript({
         acceptDeepLinkPrompt: false,
@@ -440,6 +447,7 @@ describe('issue 39 portable device contract', () => {
         timing: {
           destinationHoldMs: 8000,
           moveBudgetMs: 1200,
+          preGestureSettleMs: 6000,
           sourceHoldMs: 650,
         },
       })
@@ -716,6 +724,7 @@ console.log(JSON.stringify({
       agentDeviceSettleMarginMs: number;
       destinationHoldMs: number;
       moveBudgetMs: number;
+      preGestureSettleMs: number;
       predecessorCenterSettleMarginMs: number;
       sampleCount: number;
       sampleIntervalMs: number;
@@ -724,6 +733,8 @@ console.log(JSON.stringify({
     };
     const detoxRunner = read('e2e/contracts/portable-contract.e2e.cjs');
     const agentDeviceRunner = read('scripts/run-agent-device-pointer.mjs');
+
+    expect(timing.preGestureSettleMs).toBeGreaterThanOrEqual(5000);
 
     expect(
       pointerScenarios.every(


### PR DESCRIPTION
## Summary

- wait for the iOS accessibility runner to drain before marking gesture dispatch
- keep held-pointer evidence timing anchored immediately before the drag
- assert the minimum cooldown and replay ordering in the device-contract tests

## Evidence

The first immutable-main run completed all four runtime contracts but sampled iOS 26 free-form feedback before semantic selector resolution: https://github.com/thiagobrez/react-native-reorderable/actions/runs/33432276090/attempts/1

The full rerun then retained two iOS 26 attempts that both hit Agent Device's previous-command accessibility watchdog at the free-form drag: https://github.com/thiagobrez/react-native-reorderable/actions/runs/33432276090/attempts/2

## Verification

- yarn lint
- yarn typecheck
- yarn test --runInBand (302 tests)
- yarn test:release (16 tests)

Issue #44 remains open until the verified package is published, tagged, and released.