### PR TITLE
ci: trim the fast lane to PR-only and align the main ruleset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,11 @@
 name: CI
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
-  merge_group:
-    types:
-      - checks_requested
 
 concurrency:
-  # Keep the event name in the group: sharing one group across events once let
-  # a release-authorizing push run deadlock behind other events for 13 hours.
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -47,23 +39,10 @@ jobs:
         run: yarn prepare
 
       - name: Run unit tests
-        run: yarn test --maxWorkers=2 --coverage
+        run: yarn test --maxWorkers=2
 
       - name: Run release-policy tests
         run: yarn test:release
-
-  build-library:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Build package
-        run: yarn prepare
 
   build-android:
     runs-on: ubuntu-latest
@@ -161,6 +140,16 @@ jobs:
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Cache cocoapods
+        if: env.turbo_cache_hit != 1
+        id: cocoapods-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: example/ios/Pods
+          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cocoapods-
 
       - name: Install cocoapods
         if: env.turbo_cache_hit != 1 && steps.cocoapods-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,8 @@
 name: Documentation
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
   workflow_dispatch:
 
 permissions:
@@ -27,9 +23,6 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
-
-      - name: Typecheck guides and examples
-        run: yarn typecheck
 
       - name: Build canonical documentation
         run: yarn docs:build

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -3,8 +3,6 @@ name: Performance publication gates
 on:
   pull_request:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:
@@ -13,7 +11,6 @@ concurrency:
 
 jobs:
   geometry:
-    name: Production geometry budgets
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,7 +23,6 @@ jobs:
         run: yarn benchmark:issue40
 
   render-regressions:
-    name: Reassure children, list, and section-list paths
     runs-on: ubuntu-latest
     steps:
       - name: Checkout candidate with baseline history

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -24,9 +24,9 @@ GitHub only offers status checks that have run recently. Let the workflows run o
 5. Under **Target branches**, select **Add target**, choose **Include default branch**, and confirm that it resolves to `main`.
 6. Under **Branch rules**, enable **Require a pull request before merging**.
 7. Enable **Require status checks to pass**. Use **Add checks** to require:
-   - The five `CI` jobs: `lint`, `test`, `build-library`, `build-android`, and `build-ios`.
+   - The four `CI` jobs: `lint`, `test`, `build-android`, and `build-ios`.
    - The `Documentation` workflow's `build` job. Select the entry whose source is GitHub Actions and whose workflow is `Documentation` if GitHub shows multiple `build` checks.
-   - `Approve exact tarball for publication workflow` from `Exact package candidate`. This final job depends on every required package, performance, consumer, and device-contract job in that workflow.
+   - The two `Performance publication gates` jobs: `geometry` and `render-regressions`.
    - `Changeset requirement`, the commit-specific check created by the release-intent workflow.
 8. Enable **Require branches to be up to date before merging** so checks from an older head commit cannot authorize a merge.
 9. Leave bypass permissions empty unless the repository has a separately documented emergency policy, then select **Create**.


### PR DESCRIPTION
## What changed

Trim CI, documentation, and performance workflows to run on pull requests targeting `main` (plus manual dispatch where applicable), remove redundant merge-group and push triggers, simplify CI jobs, and add CocoaPods caching for iOS checks. Update the release documentation to match the resulting required status checks.

## Verification

- [ ] I added or updated user-observable tests where relevant.
- [ ] I ran `yarn typecheck`, `yarn lint`, and the relevant tests.
- [ ] I ran `yarn docs:build` when documentation or public API changed.
- [ ] I ran the relevant device/performance checks for interaction or performance changes.

## Release surface

- [x] I added a Changeset for a user-visible package change, or this change does not affect the published package.
- [x] I updated the canonical guides, generated API manifest, or type-checked teaching examples when their public contract changed.