### PR TITLE
ci: always run pod install in the contract job, even on a Pods cache hit (#98)

### DIFF
--- a/.github/workflows/exact-package-candidate.yml
+++ b/.github/workflows/exact-package-candidate.yml
@@ -508,9 +508,16 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: example/ios/Pods
-          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile.lock') }}
+          # The contract- prefix keeps this cache disjoint from ci.yml's
+          # cocoapods cache: this job installs the packed candidate tarball
+          # and builds Release for Detox, so its Pods tree (notably the
+          # prebuilt React core binaries) is Release-flavored. Sharing a key
+          # with ci.yml's Debug build once poisoned build-ios with
+          # release-only core binaries and failed the link on debug-only
+          # symbols.
+          key: ${{ runner.os }}-contract-cocoapods-${{ hashFiles('example/ios/Podfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cocoapods-
+            ${{ runner.os }}-contract-cocoapods-
 
       - name: Verify Apple runtime and prepare native app
         if: runner.os == 'macOS'

--- a/.github/workflows/exact-package-candidate.yml
+++ b/.github/workflows/exact-package-candidate.yml
@@ -505,7 +505,6 @@ jobs:
 
       - name: Cache cocoapods
         if: runner.os == 'macOS'
-        id: cocoapods-cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: example/ios/Pods
@@ -515,20 +514,22 @@ jobs:
 
       - name: Verify Apple runtime and prepare native app
         if: runner.os == 'macOS'
-        env:
-          COCOAPODS_CACHE_HIT: ${{ steps.cocoapods-cache.outputs.cache-hit }}
         run: |
           xcrun simctl list runtimes | grep -F '${{ matrix.runtime }}'
           brew tap wix/brew
           brew trust --formula wix/brew/applesimutils
           brew install wix/brew/applesimutils
-          if [[ "$COCOAPODS_CACHE_HIT" != 'true' ]]; then
-            (
-              cd example
-              bundle install
-              bundle exec pod install --project-directory=ios
-            )
-          fi
+          # Always run pod install, even on a Pods cache hit: React Native
+          # codegen runs inside pod install and writes its sources to
+          # example/ios/build/generated, which is outside the cached Pods
+          # directory, so a restored cache alone leaves the ReactCodegen pod
+          # target pointing at files that do not exist. The cache still pays
+          # for itself by keeping the Pods checkout warm.
+          (
+            cd example
+            bundle install
+            bundle exec pod install --project-directory=ios
+          )
           # build-framework-cache must run before detox build: without a
           # prebuilt framework cache, Detox compiles it lazily mid-build and
           # the Apple contract build fails on hosted runners.


### PR DESCRIPTION
Fixes #98.

## Root cause

#97 added a `Pods` cache to the Exact package candidate `contract` job with two structural defects:

**1. `pod install` was skipped on an exact cache hit.** React Native codegen runs inside `pod install` and writes its generated sources to `example/ios/build/generated/ios/` — outside the cached `example/ios/Pods` path — so a cache hit restores a Pods project whose `ReactCodegen` target references sources that were never generated. All three iOS contract jobs (`ios27.native`, `ios27.fallback`, `ios26.auto-fallback`) then fail in ~1 minute with `Build input file cannot be found: .../ReactCodegen/...`. The first run after #97 passed because the cache was empty; every run since (push f3b11c7, run 34016165910, and the nightly 34020531106) hit the key on the unchanged `Podfile.lock` and failed deterministically.

**2. The cache key collides with ci.yml's cocoapods cache.** Both workflows cached `example/ios/Pods` under `macOS-cocoapods-<Podfile.lock hash>`, but the contract job installs the packed candidate tarball and pod-installs for **Release** Detox builds, while `ci.yml`'s `build-ios` builds **Debug** with `RCT_USE_PREBUILT_RNCORE=1`. The 580b7f2 push run saved the Release-flavored tree on `refs/heads/main`; this PR's first `build-ios` run restored it, `pod install` saw an in-sync sandbox (only `Reorderable` was reinstalled), and the Debug app linked against Release prebuilt React core binaries — failing on debug-only symbols (`facebook::react::Props::getDebugProps`, `DebugStringConvertible` vtable, …).

## Fix

- Run `bundle install` + `bundle exec pod install` unconditionally in the contract job, keeping the cache purely as a speedup for the Pods checkout — mirroring the convention `ci.yml` already documents ("Always run the Gemfile-pinned pod install, even on a Pods cache hit") and restoring the pre-#97 install behavior.
- Prefix the contract job's cache key (`macOS-contract-cocoapods-…`) so the two configuration flavors can never alias.
- The poisoned `macOS-cocoapods-…` entry on `refs/heads/main` (cache id 7372072759) has been deleted from the Actions cache.

## Note on the fourth failed job

`android.fallback` on run 34016165910 failed differently: the `scoped-drop` case recorded a correct contract outcome, then Detox's internal `adb reverse --remove tcp:37184` teardown threw ("listener not found") and the case was classified `contract` (so no retained retry). The same job passed on the nightly run — a transient Detox teardown flake, tracked separately in #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)